### PR TITLE
Add GroupRef func

### DIFF
--- a/pkg/conjurpolicy/ref.go
+++ b/pkg/conjurpolicy/ref.go
@@ -14,6 +14,13 @@ func UserRef(id string) ResourceRef {
 	}
 }
 
+func GroupRef(id string) ResourceRef {
+	return ResourceRef{
+		Id:   id,
+		Kind: KindGroup,
+	}
+}
+
 func LayerRef(id string) ResourceRef {
 	return ResourceRef{
 		Id:   id,

--- a/pkg/conjurpolicy/types.go
+++ b/pkg/conjurpolicy/types.go
@@ -14,33 +14,33 @@ type Resources interface {
 
 type Group struct {
 	Resource    `yaml:"-"`
-	Id          string      `yaml:"id,omitempty"`
-	Annotations Annotations `yaml:"annotations,omitempty"`
-	Owner       ResourceRef `yaml:"owner,omitempty"`
+	Id          string                 `yaml:"id,omitempty"`
+	Annotations map[string]interface{} `yaml:"annotations,omitempty"`
+	Owner       ResourceRef            `yaml:"owner,omitempty"`
 }
 
-type Annotations map[string]string
+type Annotations map[string]interface{}
 
 type Variable struct {
 	Resource    `yaml:"-"`
-	Id          string      `yaml:"id"`
-	Annotations Annotations `yaml:"annotations,omitempty"`
-	Kind        string      `yaml:"kind,omitempty"`
+	Id          string                 `yaml:"id"`
+	Annotations map[string]interface{} `yaml:"annotations,omitempty"`
+	Kind        string                 `yaml:"kind,omitempty"`
 }
 
 type User struct {
 	Resource    `yaml:"-"`
-	Id          string      `yaml:"id"`
-	Owner       ResourceRef `yaml:"owner,omitempty"`
-	Annotations Annotations `yaml:"annotations,omitempty"`
+	Id          string                 `yaml:"id"`
+	Owner       ResourceRef            `yaml:"owner,omitempty"`
+	Annotations map[string]interface{} `yaml:"annotations,omitempty"`
 }
 
 type Policy struct {
 	Resource    `yaml:"-"`
-	Id          string           `yaml:"id"`
-	Annotations Annotations      `yaml:"annotations,omitempty"`
-	Owner       ResourceRef      `yaml:"owner,omitempty"`
-	Body        PolicyStatements `yaml:"body,omitempty"`
+	Id          string                 `yaml:"id"`
+	Annotations map[string]interface{} `yaml:"annotations,omitempty"`
+	Owner       ResourceRef            `yaml:"owner,omitempty"`
+	Body        PolicyStatements       `yaml:"body,omitempty"`
 }
 
 type Layer struct {
@@ -55,10 +55,10 @@ type Grant struct {
 
 type Host struct {
 	Resource    `yaml:"-"`
-	Id          string            `yaml:"id,omitempty"`
-	Owner       ResourceRef       `yaml:"owner,omitempty"`
-	Body        PolicyStatements  `yaml:"body,omitempty"`
-	Annotations map[string]string `yaml:"annotations,omitempty"`
+	Id          string                 `yaml:"id,omitempty"`
+	Owner       ResourceRef            `yaml:"owner,omitempty"`
+	Body        PolicyStatements       `yaml:"body,omitempty"`
+	Annotations map[string]interface{} `yaml:"annotations,omitempty"`
 }
 
 type Delete struct {
@@ -97,7 +97,10 @@ func (s *PolicyStatements) UnmarshalYAML(value *yaml.Node) error {
 		case KindGroup.Tag():
 			var group Group
 			if err := node.Decode(&group); err != nil {
-				return err
+				// In order to allow empty (inherited) IDs for groups we ignore this error
+				// and allow an empty group statement to be used
+				statement = Group{}
+				break
 			}
 			statement = group
 		case KindUser.Tag():

--- a/pkg/conjurpolicy/types.go
+++ b/pkg/conjurpolicy/types.go
@@ -14,7 +14,7 @@ type Resources interface {
 
 type Group struct {
 	Resource    `yaml:"-"`
-	Id          string      `yaml:"id"`
+	Id          string      `yaml:"id,omitempty"`
 	Annotations Annotations `yaml:"annotations,omitempty"`
 	Owner       ResourceRef `yaml:"owner,omitempty"`
 }

--- a/pkg/conjurpolicy/yaml_test.go
+++ b/pkg/conjurpolicy/yaml_test.go
@@ -64,12 +64,14 @@ func TestResourceMarshalUnmarshal(t *testing.T) {
 			policy: PolicyStatements{Policy{
 				Id: "policy-with-annotations",
 				Annotations: Annotations{
-					"description": "this is a test policy",
+					"description":   "this is a test policy",
+					"authn/api-key": true,
 				},
 			}},
 			expected: `- !policy
   id: policy-with-annotations
   annotations:
+    authn/api-key: true
     description: this is a test policy
 `,
 		},
@@ -134,6 +136,26 @@ func TestResourceMarshalUnmarshal(t *testing.T) {
     - !grant
       role: !layer
       member: !layer test-layer
+`,
+		}, {
+			name: "policy-with-group",
+			policy: PolicyStatements{Policy{
+				Id: "policy-with-body",
+				Body: PolicyStatements{
+					Group{},
+					Grant{
+						Role:   GroupRef(""),
+						Member: GroupRef("test-group"),
+					},
+				},
+			}},
+			expected: `- !policy
+  id: policy-with-body
+  body:
+    - !group
+    - !grant
+      role: !group
+      member: !group test-group
 `,
 		},
 	}


### PR DESCRIPTION
- Adds missing GroupRef function
- Allows groups to inherit their ID from the parent policy
- Update annotations to support non-string types 
  - Circuments issue where Go YAML converts `true` to `"true"` which may not always be desireable